### PR TITLE
Fix test errors in windows caused by encoding

### DIFF
--- a/dhall/doctest/Main.hs
+++ b/dhall/doctest/Main.hs
@@ -3,12 +3,16 @@ module Main where
 import Data.Monoid ((<>))
 import System.FilePath ((</>))
 
+import qualified GHC.IO.Encoding
 import qualified System.Directory
+import qualified System.IO
 import qualified Test.Mockery.Directory
 import qualified Test.DocTest
 
 main :: IO ()
 main = do
+   
+    GHC.IO.Encoding.setLocaleEncoding System.IO.utf8 
     pwd    <- System.Directory.getCurrentDirectory
     prefix <- System.Directory.makeAbsolute pwd
 

--- a/dhall/tests/Dhall/Test/Main.hs
+++ b/dhall/tests/Dhall/Test/Main.hs
@@ -11,8 +11,10 @@ import qualified Dhall.Test.QuickCheck
 import qualified Dhall.Test.Regression
 import qualified Dhall.Test.Tutorial
 import qualified Dhall.Test.TypeCheck
+import qualified GHC.IO.Encoding
 import qualified System.Directory
 import qualified System.Environment
+import qualified System.IO
 import qualified Test.Tasty
 
 import System.FilePath ((</>))
@@ -33,6 +35,7 @@ allTests =
 
 main :: IO ()
 main = do
+    GHC.IO.Encoding.setLocaleEncoding System.IO.utf8
     pwd <- System.Directory.getCurrentDirectory
     System.Environment.setEnv "XDG_CACHE_HOME" (pwd </> ".cache")
     Test.Tasty.defaultMain allTests


### PR DESCRIPTION
* Before the patch tests (both tasty and dictest) were failing with
```
doctest.exe: makeBools: commitBuffer: invalid argument (invalid character)
Dhall Tests
      normalization
        Tutorial examples
          normalize tasty.exe: <stdout>: commitBuffer: invalid argument (invalid character)
Command exited with code 1
```
After set the character encoding to utf-8 doctest continue failing. Setting console to utf-8 with `chcp 65001` oly left one error:
```
D:\dev\lang\eta\dhall\dhall-haskell\dhall\src/Dhall/Tutorial.hs:475: failure in expression `input auto "./baz: Double" :: IO Double'
expected: "*** Exception: "
          "\8627 ./baz: "
          "..."
          "...Error...: Missing file .../baz:"
          "..."
 but got: "*** Exception: "
          "\8627 ./baz:"
          ""
          "\ESC[1;31mError\ESC[0m: Missing file C:\\Users\\Javier\\AppData\\Local\\Temp\\mockery-2bbeef04706c5acb\\baz:"
          ""

Examples: 94  Tried: 93  Errors: 0  Failures: 1
```